### PR TITLE
Add E.split and E.route.

### DIFF
--- a/src/react.mli
+++ b/src/react.mli
@@ -174,6 +174,37 @@ module E : sig
          \[[c]\]{_<=t} [= None]}
       {- \[[until c e]\]{_t} [= None] otherwise.}} *)
 
+  (** {1:dispatching Dispatching} *)
+
+  val split : ?eq: ('i -> 'i -> bool) -> ?hash: ('i -> int) ->
+	      ('a -> 'i) -> 'a event -> 'i -> 'a event
+  (** Given an event [e] and a function [f : 'a -> 'i] which projects a value
+      of [e] to an index, then [split f e] is a function [get_ev : 'i -> 'a
+      event] such that [get_ev i] are the occurrences of [e] which project to
+      [i].  Application of [get_ev] to the same index yields the same event
+      until garbage collected.  If you need to retain a value in the returned
+      event, you must keep the existing retained value, as it it also used by
+      the implementation.  Creating many events from the same partial
+      application [get_ev] is more efficient than using of multiple
+      {!filter}ed events, since the former uses a hash table to dispatch.
+      {ul
+      {- \[[split f e i]\]{_t} [= Some v] if \[[e]\]{_t} [= Some v] and
+	 [f v] = [i]}
+      {- \[[split f e i]\]{_t} [= None] otherwise.}} *)
+
+  val route : ?eq: ('i -> 'i -> bool) -> ?hash: ('i -> int) ->
+	      'i event -> 'a event -> 'i -> 'a event
+  (** [route ei e] is a function [get_ev] such that [get_ev i] are those
+      occurrences of [e] which are simultaneous with an occurrence of [i] on
+      [ei].  The indicated partial application is essential for efficiency.
+      [get_ev] applied to equal arguments yields the same event until garbage
+      collected.  If you retain a value in the returned event, enclose the
+      existing retained value, since it used by the implementation.
+      {ul
+      {- \[[route ei e i]\]{_t} [= Some v] if \[[e]\]{_t} [= Some v] and
+	 \[[ei]\]{_t} = [i]}
+      {- \[[route ei e i]\]{_t} [= None] otherwise.}} *)
+
   (** {1:accum Accumulating} *)
 
   val accum : ('a -> 'a) event -> 'a -> 'a event    

--- a/test/_tags
+++ b/test/_tags
@@ -1,0 +1,1 @@
+<bench_split.*>: package(unix)

--- a/test/bench_split.ml
+++ b/test/bench_split.ml
@@ -1,0 +1,52 @@
+open React
+
+let n_ev_r = ref 1000
+let n_it_r = ref 1000
+
+let test_filter () =
+  let ev, set_ev = E.create () in
+  let a = Array.init !n_ev_r (fun i -> E.filter (fun (i', _) -> i' = i) ev) in
+
+  let r = ref (-1, -1, -1) in
+  for i = 0 to !n_ev_r - 1 do
+    a.(i) <- E.trace (fun (i', k) -> r := (i, i', k)) a.(i)
+  done;
+
+  for k = 0 to !n_it_r - 1 do
+    let i = Random.int !n_ev_r in
+    set_ev (i, k);
+    assert (!r = (i, i, k))
+  done;
+  a
+
+let test_split () =
+  let ev, set_ev = E.create () in
+  let get_ev = E.split fst ev in
+  let a = Array.init !n_ev_r get_ev in
+
+  let r = ref (-1, -1, -1) in
+  for i = 0 to !n_ev_r - 1 do
+    a.(i) <- E.trace (fun (i', k) -> r := (i, i', k)) a.(i)
+  done;
+
+  for k = 0 to !n_it_r - 1 do
+    let i = Random.int !n_ev_r in
+    set_ev (i, k);
+    assert (!r = (i, i, k))
+  done;
+  a
+
+let benchmark name f =
+  Gc.full_major ();
+  let tmsI = Unix.times () in
+  ignore (f ());
+  let tmsF = Unix.times () in
+  let dt = Unix.(tmsF.tms_utime -. tmsI.tms_utime) in
+  Printf.printf "%s: %g\n" name dt
+
+let () =
+  let argc = Array.length Sys.argv in
+  if argc > 1 then n_ev_r := int_of_string Sys.argv.(1);
+  if argc > 2 then n_it_r := int_of_string Sys.argv.(2);
+  benchmark "filter" test_filter;
+  benchmark "split" test_split

--- a/test/tests.itarget
+++ b/test/tests.itarget
@@ -1,3 +1,4 @@
 test.native
 clock.native
 breakout.native
+bench_split.native


### PR DESCRIPTION
This patch adds functions to dispatch one event to many.  I don't think this can be done with optimal asymptotic complexity from the existing functions.  The closest I can think of is to create a trie of events, each bisecting the incoming events to one of two sub-events, but the depth of the trie would have to be specified in advance.  Could this or some similar functionality be added?

Tests are included, but please check the way I'm creating and using the intermediate event n' for correctness.  I could also throw in a benchmark against filter.  Also, you may have another idea about naming and placement of the functions w.r.t. the documentation.
