### PR TITLE
eliminating some weak array creations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ tmp
 *~
 \#*#
 CLOCK.org
+*.native
+*.o
+*.swp

--- a/src/react.ml
+++ b/src/react.ml
@@ -20,7 +20,7 @@ module Wa = struct
      For now the arrays only grow. We could try to compact and
      downsize the array in scan_add if a threshold of empty slots is
      exceeded. *)
-
+jddu
   let create size = { arr = Weak.create size; len = 0 }
   let length a = a.len
   let is_empty a =
@@ -31,7 +31,7 @@ module Wa = struct
       true
     with Exit -> false
 
-  let clear a = a.arr <- Weak.create 0; a.len <- 0
+  let clear a = a.len <- 0
   let get a i = Weak.get a.arr i
   let set a i = Weak.set a.arr i
   let swap a i i' =
@@ -300,7 +300,7 @@ module Step = struct                                       (* Update steps. *)
   let rec execute c =
     let eops c = List.iter (fun op -> op ()) c.eops; c.eops <- [] in
     let cops c = List.iter (fun op -> op ()) c.cops; c.cops <- [] in
-    let finish c = c.over <- true; c.heap <- Wa.create 0 in
+    let finish c = c.over <- true; Wa.clear c.heap in
     let rec update c = match H.take c.heap with
     | Some n when n.rank <> delayed_rank -> n.update c; update c
     | Some n ->

--- a/src/react.ml
+++ b/src/react.ml
@@ -20,7 +20,7 @@ module Wa = struct
      For now the arrays only grow. We could try to compact and
      downsize the array in scan_add if a threshold of empty slots is
      exceeded. *)
-jddu
+
   let create size = { arr = Weak.create size; len = 0 }
   let length a = a.len
   let is_empty a =


### PR DESCRIPTION
i noticed that my simulation-minibenchmarks spent most of their time in weak array creation and garbage collection. here is a naive attempt at reducing this load. 

the result is that overhanging weak arrays stay around but will be collected whenever it's convenient. it seems that within react.ml, having weak arrays longer than Wa.len says, is not a problem. Wa.t is not public so there should not be a problem for clients

the tests in test.ml pass. also, in one mini-benchmark, 
https://gist.github.com/nilsbecker/2ec8d0a136e2fcc20184#file-react_minibenchmark-ml
this version is up to 20% faster

i am not sure if the Wa.clear is needed on finish. anyway, the whole thing is pretty much a stab in the dark, so could be nonsense.
