### PR TITLE
memoization of step heaps, effectively preallocating weak arrays

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ tmp
 *.native
 *.byte
 *.install
+CLOCK.org
+*.o
+*.swp

--- a/src/react.ml
+++ b/src/react.ml
@@ -19,7 +19,7 @@ module Wa = struct
      For now the arrays only grow. We could try to compact and
      downsize the array in scan_add if a threshold of empty slots is
      exceeded. *)
-jddu
+
   let create size = { arr = Weak.create size; len = 0 }
   let length a = a.len
   let is_empty a =

--- a/src/react.ml
+++ b/src/react.ml
@@ -19,7 +19,7 @@ module Wa = struct
      For now the arrays only grow. We could try to compact and
      downsize the array in scan_add if a threshold of empty slots is
      exceeded. *)
-
+jddu
   let create size = { arr = Weak.create size; len = 0 }
   let length a = a.len
   let is_empty a =
@@ -30,7 +30,7 @@ module Wa = struct
       true
     with Exit -> false
 
-  let clear a = a.arr <- Weak.create 0; a.len <- 0
+  let clear a = a.len <- 0
   let get a i = Weak.get a.arr i
   let set a i = Weak.set a.arr i
   let swap a i i' =
@@ -299,7 +299,7 @@ module Step = struct                                       (* Update steps. *)
   let rec execute c =
     let eops c = List.iter (fun op -> op ()) c.eops; c.eops <- [] in
     let cops c = List.iter (fun op -> op ()) c.cops; c.cops <- [] in
-    let finish c = c.over <- true; c.heap <- Wa.create 0 in
+    let finish c = c.over <- true; Wa.clear c.heap in
     let rec update c = match H.take c.heap with
     | Some n when n.rank <> delayed_rank -> n.update c; update c
     | Some n ->


### PR DESCRIPTION
this is another performance improvement suggestion. it's entirely possible that this breaks the JS backend. i have not tried. 

weak array creations are reduced further by keeping old weak array heaps from previous steps around in a primitive stack. in my benchmarks where steps are fired in a tight loop, the commit cee407f decreased the runtime of a simulation between 20 and 40%. similar improvements are also seen in the minibenchmark https://gist.github.com/nilsbecker/2ec8d0a136e2fcc20184#file-react_minibenchmark-ml .  compared to react 1.2.0, in my specific use cases, this in some cases gives a speedup of around 2 times.
