### PR TITLE
Use Toploop.load_file for 4.14.0+trunk

### DIFF
--- a/src/react_top.ml
+++ b/src/react_top.ml
@@ -3,7 +3,7 @@
    Distributed under the ISC license, see terms at the end of the file.
   ---------------------------------------------------------------------------*)
 
-let () = ignore (Toploop.use_file Format.err_formatter "react_top_init.ml")
+let () = ignore (Toploop.load_file Format.err_formatter "react_top_init.ml")
 
 (*---------------------------------------------------------------------------
    Copyright (c) 2014 The react programmers


### PR DESCRIPTION
4.14.0+trunk has deprecated `Toploop.use_file` and we now need to use `Toploop.load_file`.